### PR TITLE
fix: fixed issue with previous title remaining

### DIFF
--- a/application/web/web.js
+++ b/application/web/web.js
@@ -252,5 +252,7 @@ function saveCurrentEntry() {
 
     button_list.append(newEntry);
     button_list.append(article);
+    titleTextArea.value = 'Untitled';
+    titleTextArea.className = 'placeholder';
     hideTextEditor();
 }


### PR DESCRIPTION
Fixed issue where the title of the previously saved entry remained in the title input box. Now says untitled when clicking new entry.

#81 
