### PR TITLE
fix: electron windows compatability

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -2971,9 +2971,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
       "dev": true,
       "funding": [
         {
@@ -2990,10 +2990,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
+        "caniuse-lite": "^1.0.30001629",
+        "electron-to-chromium": "^1.4.796",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "update-browserslist-db": "^1.0.16"
       },
       "bin": {
         "browserslist": "cli.js"

--- a/application/package.json
+++ b/application/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint . --ignore-pattern \"web/scripts/ajax/*\"",
     "prod": "NODE_ENV=production electron .",
     "dev": "NODE_ENV=development electron .",
+    "dev:windows": "set NODE_ENV=development & electron .",
     "generate-docs": "jsdoc web -r -d ../docs",
     "test": "jest --testPathPattern=./tests/unit/",
     "test:e2e": "npx playwright test tests/e2e/",


### PR DESCRIPTION
Fix #128 

added:
"dev:windows": "set NODE_ENV=development & electron .",

use command:

"npm run dev:windows"
to run npm run on windows machines

the npm version was updated.